### PR TITLE
fix array to string conversion

### DIFF
--- a/src/Adapter/GuzzleHttpAdapter.php
+++ b/src/Adapter/GuzzleHttpAdapter.php
@@ -118,9 +118,9 @@ class GuzzleHttpAdapter implements AdapterInterface
         }
 
         return [
-            'reset' => (int) (string) $this->response->getHeader('RateLimit-Reset'),
-            'remaining' => (int) (string) $this->response->getHeader('RateLimit-Remaining'),
-            'limit' => (int) (string) $this->response->getHeader('RateLimit-Limit'),
+            'reset' => reset($this->response->getHeader('RateLimit-Reset')),
+            'remaining' => reset($this->response->getHeader('RateLimit-Remaining')),
+            'limit' => reset($this->response->getHeader('RateLimit-Limit')),
         ];
     }
 


### PR DESCRIPTION
When using the GuzzleHttpAdapter and calling the RateLimit API to return the current usage limits I get the following PHP notices:

```
[11-Nov-2019 10:12:40 UTC] PHP Notice:  Array to string conversion in /digitalocean-v2/src/Adapter/GuzzleHttpAdapter.php on line 121
[11-Nov-2019 10:12:40 UTC] PHP Notice:  Array to string conversion in /digitalocean-v2/src/Adapter/GuzzleHttpAdapter.php on line 122
[11-Nov-2019 10:12:40 UTC] PHP Notice:  Array to string conversion in /digitalocean-v2/src/Adapter/GuzzleHttpAdapter.php on line 123
```

The response that comes back from the GuzzleHttpAdapter looks like this:

```
[Ratelimit-Limit] => Array(
    [0] => 5000
)
[Ratelimit-Remaining] => Array(
    [0] => 4992
)
[Ratelimit-Reset] => Array(
    [0] => 1573465757
)
```

And the final RateLimit object looks like this:

```
DigitalOceanV2\Entity\RateLimit Object
(
    [limit] => 0
    [remaining] => 0
    [reset] => 0
)
```

The following changes fixes the issue and returns the values correctly

The final RateLimit Object with these changes looks like this:

```
DigitalOceanV2\Entity\RateLimit Object
(
    [limit] => 5000
    [remaining] => 4990
    [reset] => 1573465757
)
```